### PR TITLE
Use Coinbase Exchange candles for historical prices

### DIFF
--- a/coinbase_utils.py
+++ b/coinbase_utils.py
@@ -67,6 +67,8 @@ def get_spot_price_for_date(currency_pair, date):
         raise RuntimeError(f"Failed to fetch price data: {history['error']}")
     if not history['candles']:
         raise ValueError(f'No candle data available for {currency_pair} on {date}')
+    if history['candles'][0]['date'] != date:
+        raise ValueError(f'No candle data available for {currency_pair} on {date}')
     return history['candles'][0]['close']
 
 

--- a/coinbase_utils.py
+++ b/coinbase_utils.py
@@ -1,3 +1,7 @@
+from datetime import datetime
+import time
+
+import requests
 from coinbase.wallet.client import Client
 
 import printer
@@ -5,15 +9,65 @@ import utils
 
 
 coinbase_client = Client('<KEY_NOT_NEEDED>', '<SECRET_NOT_NEEDED>')
+COINBASE_EXCHANGE_API_BASE = 'https://api.exchange.coinbase.com'
+DAILY_GRANULARITY_SECONDS = 86400
+RETRY_STATUSES = {429, 500, 502, 503, 504}
+MAX_RETRIES = 3
+BACKOFF_SECONDS = 0.5
+REQUEST_TIMEOUT_SECONDS = 10
 
 
 def get_current_price(currency_pair):
     return coinbase_client.get_spot_price(currency_pair=currency_pair)['amount']
 
 
+def get_price_history(asset, quote, start_date, end_date):
+    product_id = f'{asset}-{quote}'
+    start_timestamp = f'{start_date}T00:00:00Z'
+    end_timestamp = f'{end_date}T00:00:00Z'
+
+    response, error = _fetch_candles(product_id, start_timestamp, end_timestamp)
+    history = {'product': product_id, 'granularity': DAILY_GRANULARITY_SECONDS, 'candles': []}
+
+    if error:
+        history['error'] = error
+        return history
+
+    try:
+        candles = response.json()
+    except ValueError:
+        history['error'] = {'status': response.status_code, 'message': 'Invalid JSON response'}
+        return history
+
+    if not candles:
+        return history
+
+    for candle in candles:
+        # Coinbase Exchange candle format: [time, low, high, open, close, volume]
+        time_epoch = candle[0]
+        history['candles'].append({
+            'date': datetime.utcfromtimestamp(time_epoch).strftime('%Y-%m-%d'),
+            'time': time_epoch,
+            'open': candle[3],
+            'high': candle[2],
+            'low': candle[1],
+            'close': candle[4],
+            'volume': candle[5],
+        })
+
+    history['candles'].sort(key=lambda entry: entry['time'])
+    return history
+
+
 def get_spot_price_for_date(currency_pair, date):
-    price_data = coinbase_client.get_spot_price(currency_pair=currency_pair, date=date)
-    return price_data['amount']
+    asset, quote = currency_pair.split('-')
+    end_date = utils.get_day_after(date)
+    history = get_price_history(asset, quote, date, end_date)
+    if history.get('error'):
+        raise RuntimeError(f"Failed to fetch price data: {history['error']}")
+    if not history['candles']:
+        raise ValueError(f'No candle data available for {currency_pair} on {date}')
+    return history['candles'][0]['close']
 
 
 def get_price_dict_for_dates(currency_pair, dates):
@@ -48,3 +102,32 @@ def update_price_data(price_data_csv, currency_pair, yesterday, current_price):
     printer.current_price(coin, current_price)
     with open(price_data_csv, 'a') as fd:
         fd.write(f'NOW,{current_price}')
+
+
+def _fetch_candles(product_id, start_timestamp, end_timestamp):
+    url = f'{COINBASE_EXCHANGE_API_BASE}/products/{product_id}/candles'
+    params = {
+        'start': start_timestamp,
+        'end': end_timestamp,
+        'granularity': DAILY_GRANULARITY_SECONDS,
+    }
+    for attempt in range(MAX_RETRIES + 1):
+        try:
+            response = requests.get(url, params=params, timeout=REQUEST_TIMEOUT_SECONDS)
+        except requests.RequestException as error:
+            return None, {'message': 'Request failed', 'details': str(error)}
+
+        if response.status_code == 200:
+            return response, None
+
+        if response.status_code in RETRY_STATUSES and attempt < MAX_RETRIES:
+            time.sleep(BACKOFF_SECONDS * (2 ** attempt))
+            continue
+
+        return response, {
+            'status': response.status_code,
+            'message': 'Non-200 response',
+            'body': response.text,
+        }
+
+    return None, {'message': 'Request retries exhausted'}

--- a/coinbase_utils_test.py
+++ b/coinbase_utils_test.py
@@ -1,0 +1,84 @@
+import coinbase_utils
+
+
+class FakeResponse:
+    def __init__(self, status_code, payload):
+        self.status_code = status_code
+        self._payload = payload
+        self.text = str(payload)
+
+    def json(self):
+        return self._payload
+
+
+def test_get_price_history_parses_and_sorts(monkeypatch):
+    candles = [
+        [1609545600, 900.0, 1100.0, 950.0, 1000.0, 12.5],
+        [1609459200, 800.0, 1000.0, 900.0, 950.0, 10.0],
+    ]
+
+    def fake_get(url, params, timeout):
+        return FakeResponse(200, candles)
+
+    monkeypatch.setattr(coinbase_utils.requests, 'get', fake_get)
+
+    history = coinbase_utils.get_price_history('BTC', 'USD', '2021-01-01', '2021-01-03')
+
+    assert history['product'] == 'BTC-USD'
+    assert history['granularity'] == coinbase_utils.DAILY_GRANULARITY_SECONDS
+    assert [entry['time'] for entry in history['candles']] == [1609459200, 1609545600]
+    assert history['candles'][0]['date'] == '2021-01-01'
+    assert history['candles'][0]['open'] == 900.0
+    assert history['candles'][0]['high'] == 1000.0
+    assert history['candles'][0]['low'] == 800.0
+    assert history['candles'][0]['close'] == 950.0
+    assert history['candles'][0]['volume'] == 10.0
+
+
+def test_get_price_history_builds_day_boundary_params(monkeypatch):
+    captured = {}
+
+    def fake_get(url, params, timeout):
+        captured['url'] = url
+        captured['params'] = params
+        return FakeResponse(200, [])
+
+    monkeypatch.setattr(coinbase_utils.requests, 'get', fake_get)
+
+    coinbase_utils.get_price_history('BTC', 'USD', '2017-01-01', '2017-01-02')
+
+    assert captured['url'].endswith('/products/BTC-USD/candles')
+    assert captured['params'] == {
+        'start': '2017-01-01T00:00:00Z',
+        'end': '2017-01-02T00:00:00Z',
+        'granularity': coinbase_utils.DAILY_GRANULARITY_SECONDS,
+    }
+
+
+def test_get_price_history_empty_results(monkeypatch):
+    monkeypatch.setattr(
+        coinbase_utils.requests,
+        'get',
+        lambda url, params, timeout: FakeResponse(200, []),
+    )
+
+    history = coinbase_utils.get_price_history('ETH', 'USD', '2021-02-01', '2021-02-02')
+
+    assert history['candles'] == []
+    assert history.get('error') is None
+
+
+def test_get_price_history_non_200(monkeypatch):
+    call_count = {'count': 0}
+
+    def fake_get(url, params, timeout):
+        call_count['count'] += 1
+        return FakeResponse(500, {'message': 'server error'})
+
+    monkeypatch.setattr(coinbase_utils.requests, 'get', fake_get)
+    monkeypatch.setattr(coinbase_utils.time, 'sleep', lambda *_: None)
+
+    history = coinbase_utils.get_price_history('BTC', 'USD', '2020-01-01', '2020-01-02')
+
+    assert history['error']['status'] == 500
+    assert call_count['count'] == coinbase_utils.MAX_RETRIES + 1


### PR DESCRIPTION
### Motivation
- The legacy Coinbase Wallet `spot` endpoint with a `date` parameter is unreliable for older dates and can return `rate not found`, so switch to the Coinbase Exchange candles endpoint for robust daily historical OHLCV data.

### Description
- Added `get_price_history(asset, quote, start_date, end_date)` that maps `asset`+`quote` → `PRODUCT_ID`, requests daily candles with ISO8601 `start`/`end` and `granularity=86400`, parses each candle tuple `[time, low, high, open, close, volume]`, converts `time` to `YYYY-MM-DD`, and sorts candles ascending by `time`.
- Replaced the previous date-based spot lookup by updating `get_spot_price_for_date` to call the new history function and return the candle `close` for a single-day request while keeping the external interface intact.
- Implemented `_fetch_candles` using `requests` with basic retry/backoff for transient statuses (`429`, `5xx`) and structured error returns; added configuration constants and brief inline comments describing tuple ordering and date conversions.
- Added unit tests `coinbase_utils_test.py` that cover parsing and ordering of candles, day-boundary parameter construction, empty results handling, and non-200 retry/error behavior.

### Testing
- Ran `pytest -q`; collection failed due to missing test-time dependencies: `requests`, `gspread`, and `pandas` (these are required to import modules and run the suite in this environment).
- The new `coinbase_utils_test.py` uses monkeypatch to simulate `requests.get` responses and exercises parsing, ordering, day-boundary params, empty response, and retry behavior; these tests should pass when `requests` is installed.
- No external credentials or authentication were added and the implementation preserves the public function names used by the app.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697f6a9a8ddc8321a9c67edfb9dd3f9b)