### PR TITLE
Add domain models and normalize Coinbase candles with UTC handling

### DIFF
--- a/coinbase_utils_test.py
+++ b/coinbase_utils_test.py
@@ -35,6 +35,23 @@ def test_get_price_history_parses_and_sorts(monkeypatch):
     assert history['candles'][0]['volume'] == 10.0
 
 
+def test_get_price_history_filters_to_range(monkeypatch):
+    candles = [
+        [1609459200, 800.0, 1000.0, 900.0, 950.0, 10.0],  # 2021-01-01
+        [1609545600, 900.0, 1100.0, 950.0, 1000.0, 12.5],  # 2021-01-02
+        [1609632000, 950.0, 1150.0, 1000.0, 1100.0, 15.0],  # 2021-01-03
+    ]
+
+    def fake_get(url, params, timeout):
+        return FakeResponse(200, candles)
+
+    monkeypatch.setattr(coinbase_utils.requests, 'get', fake_get)
+
+    history = coinbase_utils.get_price_history('BTC', 'USD', '2021-01-01', '2021-01-03')
+
+    assert [entry['date'] for entry in history['candles']] == ['2021-01-01', '2021-01-02']
+
+
 def test_get_price_history_builds_day_boundary_params(monkeypatch):
     captured = {}
 

--- a/domain.py
+++ b/domain.py
@@ -1,0 +1,53 @@
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import List
+
+
+DATE_FORMAT = '%Y-%m-%d'
+
+
+def parse_utc_date(date_str: str) -> datetime:
+    return datetime.strptime(date_str, DATE_FORMAT).replace(tzinfo=timezone.utc)
+
+
+@dataclass(frozen=True)
+class TimeRange:
+    start: datetime
+    end: datetime
+
+    def contains_epoch(self, epoch_seconds: int) -> bool:
+        timestamp = datetime.fromtimestamp(epoch_seconds, tz=timezone.utc)
+        return self.start <= timestamp < self.end
+
+
+@dataclass(frozen=True)
+class Candle:
+    time: int
+    open: float
+    high: float
+    low: float
+    close: float
+    volume: float
+
+    @property
+    def date(self) -> str:
+        return datetime.fromtimestamp(self.time, tz=timezone.utc).strftime(DATE_FORMAT)
+
+    def to_dict(self) -> dict:
+        return {
+            'date': self.date,
+            'time': self.time,
+            'open': self.open,
+            'high': self.high,
+            'low': self.low,
+            'close': self.close,
+            'volume': self.volume,
+        }
+
+
+@dataclass(frozen=True)
+class Series:
+    asset: str
+    quote: str
+    granularity: int
+    candles: List[Candle]

--- a/utils.py
+++ b/utils.py
@@ -1,5 +1,5 @@
 import csv
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from os import path, mkdir
 
 import gspread
@@ -9,6 +9,7 @@ from oauth2client.service_account import ServiceAccountCredentials
 import config
 import google_utils
 import printer
+from domain import DATE_FORMAT
 
 
 workbook_name = config.google_workbook_name
@@ -26,18 +27,19 @@ def import_csv_as_list(csv_filename):
 
 # tested
 def get_yesterday():
-    return datetime.strftime(datetime.now() - timedelta(1), '%Y-%m-%d')
+    utc_now = datetime.now(timezone.utc)
+    return datetime.strftime(utc_now - timedelta(1), DATE_FORMAT)
 
 
 # tested
 def get_date_range(start_date, end_date):
-    return [date.strftime('%Y-%m-%d') for date in pd.date_range(start_date, end_date)]
+    return [date.strftime(DATE_FORMAT) for date in pd.date_range(start_date, end_date)]
 
 
 # tested
 def get_day_after(date):
     date_formatted = datetime.strptime(date, '%Y-%m-%d')
-    return datetime.strftime(date_formatted + timedelta(1), '%Y-%m-%d')
+    return datetime.strftime(date_formatted + timedelta(1), DATE_FORMAT)
 
 
 # tested

--- a/utils_test.py
+++ b/utils_test.py
@@ -1,7 +1,7 @@
 import os
 import re
 import uuid
-from datetime import date, datetime
+from datetime import date, datetime, timezone
 
 import pandas as pd
 
@@ -21,7 +21,7 @@ def test_import_csv_as_list():
 
 def test_get_yesterday():
     date_pattern = re.compile('[\\d]{4}-[\\d]{2}-[\\d]{2}')
-    today = datetime.strftime(datetime.now(), '%Y-%m-%d')
+    today = datetime.strftime(datetime.now(timezone.utc), '%Y-%m-%d')
 
     actual = utils.get_yesterday()
 


### PR DESCRIPTION
### Motivation
- Centralize time and candle semantics to avoid off-by-one and timezone bugs by introducing a small domain model for candles, series and UTC time ranges.
- Make provider parsing deterministic and robust against provider quirks (unordered responses, malformed tuples, out-of-range candles).
- Improve retry behavior to reduce thundering retries and make failures explicit for better observability and downstream handling.

### Description
- Added `domain.py` introducing `Candle`, `Series`, `TimeRange`, `DATE_FORMAT`, and `parse_utc_date` to provide a canonical domain model and UTC parsing helpers.
- Updated `coinbase_utils.py` to use `TimeRange(parse_utc_date(...))`, to normalize Coinbase tuples via `_normalize_coinbase_candles()` which validates tuple shape, filters to the `[start, end)` time range, converts to `Candle` objects, and returns a deterministically sorted `Series`.
- Added jittered exponential backoff to `_fetch_candles()` retry logic and converted normalization errors into structured history errors.
- Updated `utils.py` to use UTC-aware `get_yesterday()` and a single `DATE_FORMAT` constant to ensure consistent date formatting across the app.
- Added/updated tests: `coinbase_utils_test.py` now includes `test_get_price_history_filters_to_range` to assert range filtering, and `utils_test.py` was adjusted to check UTC-based `get_yesterday()` behavior.

### Testing
- Ran the test suite with `pytest -q` in this environment and test collection failed due to missing external dependencies (`ModuleNotFoundError` for `requests`, `gspread`, and `pandas`).
- Unit tests added: `test_get_price_history_filters_to_range` (new) and existing Coinbase parsing/sorting tests were left intact for local execution where dependencies are available.
- No further automated tests ran successfully in CI here because environment lacks required third-party libraries; the new tests are designed to pass under a standard dev environment with `requests`, `gspread`, and `pandas` installed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697f75bcd83c8321b21c50c629da6f37)