### PR TITLE
Refactors

### DIFF
--- a/coinbase_utils.py
+++ b/coinbase_utils.py
@@ -48,7 +48,15 @@ def get_price_history(asset, quote, start_date, end_date):
         if not payload:
             continue
 
-        candles = domain.parse_coinbase_candles(payload)
+        try:
+            candles = domain.parse_coinbase_candles(payload)
+        except ValueError as error:
+            history['error'] = {
+                'status': response.status_code,
+                'message': 'Invalid candle payload',
+                'details': str(error),
+            }
+            return history
         candles = [candle for candle in candles if time_range.contains_epoch(candle.time)]
         collected.extend(candles)
 


### PR DESCRIPTION
refactor: add domain layer, UTC dates, windowed Coinbase fetches, and retries with jitter

  - Introduce domain.py: TimeRange, Candle, Series; parse_coinbase_candles validates and raises
  - Use UTC and shared DATE_FORMAT in utils (get_yesterday, get_date_range, get_day_after)
  - Coinbase: split long ranges into configurable windows (config.coinbase_max_window_days), merge and dedupe candles; retry on RequestException with backoff and jitter
  - Filter candles by TimeRange.contains_epoch; preserve existing history dict API via Series.to_history()
  - Add REFACTORING_PROPOSAL.md; fix printer typo (compatability → compatibility)