### PR TITLE
Handle invalid Coinbase candle payloads and add tests

### DIFF
--- a/coinbase_utils.py
+++ b/coinbase_utils.py
@@ -48,7 +48,15 @@ def get_price_history(asset, quote, start_date, end_date):
         if not payload:
             continue
 
-        candles = domain.parse_coinbase_candles(payload)
+        try:
+            candles = domain.parse_coinbase_candles(payload)
+        except ValueError as error:
+            history['error'] = {
+                'status': response.status_code,
+                'message': 'Invalid candle payload',
+                'details': str(error),
+            }
+            return history
         candles = [candle for candle in candles if time_range.contains_epoch(candle.time)]
         collected.extend(candles)
 


### PR DESCRIPTION
### Motivation
- Prevent unhandled exceptions when Coinbase returns invalid JSON or malformed candle arrays and provide a structured error back to callers.

### Description
- Catch `ValueError` from `domain.parse_coinbase_candles` in `coinbase_utils.get_price_history` and return `history['error']` with `status`, `message: 'Invalid candle payload'`, and `details` containing the exception message.
- Preserve existing behavior for empty responses and non-200 responses while making payload errors explicit.
- Add `FakeJsonErrorResponse` test helper and two tests: `test_get_price_history_invalid_json` and `test_get_price_history_invalid_payload` in `coinbase_utils_test.py` to cover invalid JSON and malformed payload cases.
- Files changed: `coinbase_utils.py`, `coinbase_utils_test.py`.

### Testing
- Ran `pytest`, which aborted during collection due to missing third‑party packages (`requests`, `gspread`, `pandas`) causing import errors and preventing the test suite from completing.  The new tests are present and should pass in an environment with those dependencies installed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697ff4b5a1a88321a024e39dbe927a91)